### PR TITLE
Use title and subtext for sentiment

### DIFF
--- a/llm/openai_wrapper.py
+++ b/llm/openai_wrapper.py
@@ -1,31 +1,4 @@
 import os
-from openai import OpenAI
-from dotenv import load_dotenv
-
-load_dotenv()
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
-def analyze_sentiment(review_excerpt: str) -> str:
-    """
-    Uses OpenAI Chat API to determine if the reviewer recommends the movie.
-    """
-    prompt = f"""
-Here is a short excerpt from a film review:
-
-\"\"\"\n{review_excerpt}\n\"\"\"
-
-Based on this, does the reviewer recommend the movie? Reply only with:
-Yes or No, and a 1-line explanation.
-"""
-
-    response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.3,
-    )
-
-    return response.choices[0].message.content.strip()
-import os
 from dotenv import load_dotenv
 from openai import OpenAI
 
@@ -59,24 +32,34 @@ Reply with Yes or No, followed by a one-line reason.
 
     return response.choices[0].message.content.strip()
 
-def analyze_sentiment(review_excerpt: str) -> str:
-    """
-    Uses GPT to determine if the reviewer recommends the movie.
-    Returns: 'Yes – ...' or 'No – ...'
-    """
+def analyze_sentiment(title: str, subtext: str) -> str:
+    """Return whether the reviewer recommends the movie as Yes, No or Maybe."""
+
     prompt = f"""
-Here is a short excerpt from a film review:
+You are an expert assistant analysing film reviews from the blog
+baradwajrangan.wordpress.com. Some posts on this site are not
+actual movie reviews while others, like the one on "DNA" by Nelson,
+are strongly negative. Keep these nuances in mind.
 
-\"\"\"\n{review_excerpt}\n\"\"\"
+Below are the post title and a short blurb from the review:
 
-Based on this, does the reviewer recommend the movie? 
-Reply only with Yes or No and a one-line explanation.
+Title:
+"""{title}"""
+
+Subtext:
+"""{subtext}"""
+
+Determine whether the author recommends watching the movie.
+Look for sarcasm or negative phrasing.
+If the snippet does not appear to actually contain a movie review,
+reply with "No – not a review".
+Otherwise answer "Yes", "No" or "Maybe" followed by a concise reason.
 """
 
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
-        temperature=0.3,
+        temperature=0.2,
     )
 
     return response.choices[0].message.content.strip()

--- a/main.py
+++ b/main.py
@@ -29,8 +29,8 @@ def main():
                 print("⏭️ Skipping: Not a review post.\n")
                 continue
 
-            # Step 2: Sentiment analysis
-            sentiment = analyze_sentiment(data["full_review"])
+            # Step 2: Sentiment analysis using title and subtext
+            sentiment = analyze_sentiment(data["title"], data["short_review"])
             print(f"🤖 Sentiment: {sentiment}\n")
 
             # Only keep recommended movies


### PR DESCRIPTION
## Summary
- refine `analyze_sentiment` to analyze title and subtext
- update call site in `main.py`
- clarify prompt to return `No – not a review` if text isn't a review
- include `Maybe` as a possible recommendation result

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858fc9f2a088324870fada22ca7c7be