### PR TITLE
Implement persistent crawling with sentiment updates

### DIFF
--- a/crawler/fetch_links.py
+++ b/crawler/fetch_links.py
@@ -4,10 +4,10 @@ from bs4 import BeautifulSoup
 BASE_URL = "https://baradwajrangan.wordpress.com"
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
-def get_post_links(max_pages=5, max_links=100):
-    links = []
 
-    for page_num in range(1, max_pages + 1):
+def get_post_links(max_pages=5, start_page=1, start_index=0):
+    """Yield blog post links one by one starting from the given page/index."""
+    for page_num in range(start_page, max_pages + 1):
         url = f"{BASE_URL}/page/{page_num}/"
         print(f"\n📄 Page {page_num}: Scanning {url}")
 
@@ -16,23 +16,15 @@ def get_post_links(max_pages=5, max_links=100):
             res.raise_for_status()
             soup = BeautifulSoup(res.text, "html.parser")
 
-            count_before = len(links)
-            for a in soup.select("div.post h2 a[rel='bookmark']"):
-                href = a.get('href')
-                if href and href not in links:
-                    links.append(href)
+            link_tags = soup.select("div.post h2 a[rel='bookmark']")
+            for idx, a in enumerate(link_tags):
+                if page_num == start_page and idx < start_index:
+                    continue
+                href = a.get("href")
+                if href:
                     print(f"✅ Found: {href}")
-                if len(links) >= max_links:
-                    break
-
-            count_after = len(links)
-            print(f"📝 Collected {count_after - count_before} new links (Total: {count_after})")
-
-            if len(links) >= max_links:
-                break
-
+                    yield page_num, idx, href
         except Exception as e:
             print(f"❌ Error on page {page_num}: {e}")
             break
 
-    return links

--- a/crawler/parse_post.py
+++ b/crawler/parse_post.py
@@ -18,15 +18,29 @@ def parse_post(url, max_chars=1200):
     title_tag = soup.select_one("div#header-about h1")
     title = title_tag.get_text(strip=True) if title_tag else "Untitled"
 
+    # Extract date
+    date_tag = soup.select_one("time.entry-date") or soup.select_one("span.published")
+    post_date = date_tag.get_text(strip=True) if date_tag else ""
+
+    # Extract reviewer name if present
+    author_tag = (
+        soup.select_one("span.author a")
+        or soup.select_one("a[rel='author']")
+        or soup.select_one("span.fn")
+    )
+    reviewer = author_tag.get_text(strip=True) if author_tag else ""
+
     # Extract review paragraphs
     content_div = soup.select_one("div.entry")
     paragraphs = content_div.find_all("p") if content_div else []
 
     short_review = paragraphs[0].get_text(strip=True) if len(paragraphs) >= 1 else ""
-    full_review = paragraphs[1].get_text(strip=True) if len(paragraphs) >= 2 else ""
+    full_review = " ".join(p.get_text(strip=True) for p in paragraphs[1:])
 
     return {
         "title": title,
+        "date": post_date,
+        "reviewer": reviewer,
         "short_review": short_review,
         "full_review": full_review[:max_chars]
     }

--- a/llm/openai_wrapper.py
+++ b/llm/openai_wrapper.py
@@ -1,82 +1,49 @@
 import os
-from openai import OpenAI
 from dotenv import load_dotenv
+from openai import OpenAI
 
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-def analyze_sentiment(review_excerpt: str) -> str:
-    """
-    Uses OpenAI Chat API to determine if the reviewer recommends the movie.
-    """
-    prompt = f"""
-Here is a short excerpt from a film review:
-
-\"\"\"\n{review_excerpt}\n\"\"\"
-
-Based on this, does the reviewer recommend the movie? Reply only with:
-Yes or No, and a 1-line explanation.
-"""
-
-    response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.3,
-    )
-
-    return response.choices[0].message.content.strip()
-import os
-from dotenv import load_dotenv
-from openai import OpenAI
-
-# Load API key from .env
-load_dotenv()
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 def is_film_review(title: str, short_review: str) -> str:
-    """
-    Uses GPT to decide if this blog post looks like a film review.
-    Returns: 'Yes – ...' or 'No – ...'
-    """
+    """Return 'Yes' or 'No' along with a short explanation."""
     prompt = f"""
 Given the following blog post metadata:
 
 Title:
-\"\"\"{title}\"\"\"
+"""{title}"""
 
 Short Review Snippet:
-\"\"\"{short_review}\"\"\"
+"""{short_review}"""
 
 Does this appear to be a film review?
 Reply with Yes or No, followed by a one-line reason.
 """
-
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.2,
     )
-
     return response.choices[0].message.content.strip()
 
+
 def analyze_sentiment(review_excerpt: str) -> str:
-    """
-    Uses GPT to determine if the reviewer recommends the movie.
-    Returns: 'Yes – ...' or 'No – ...'
-    """
+    """Return 'Yes' or 'No' recommendation with a short explanation."""
     prompt = f"""
 Here is a short excerpt from a film review:
 
-\"\"\"\n{review_excerpt}\n\"\"\"
-
-Based on this, does the reviewer recommend the movie? 
-Reply only with Yes or No and a one-line explanation.
+"""
+{review_excerpt}
 """
 
+Based on this, does the reviewer recommend the movie?
+Reply only with Yes or No and a one-line explanation.
+"""
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
         temperature=0.3,
     )
-
     return response.choices[0].message.content.strip()
+

--- a/main.py
+++ b/main.py
@@ -1,62 +1,57 @@
 from crawler.fetch_links import get_post_links
 from crawler.parse_post import parse_post
 from llm.openai_wrapper import is_film_review, analyze_sentiment
+from utils.db import init_db, save_post, fetch_unanalyzed, update_recommendation
+from utils.state import load_state, save_state
 
-MAX_PAGES = 1
-MAX_LINKS = 100
+MAX_PAGES = 5
 
-def main():
-    print("🔍 Fetching post links...")
-    links = get_post_links(max_pages=MAX_PAGES, max_links=MAX_LINKS)
-    print(f"\n📦 Total collected: {len(links)} post links.\n")
 
-    curated = []
-
-    for i, link in enumerate(links):
-        print(f"\n🔗 [{i+1}/{len(links)}] {link}")
+def crawl_and_store() -> None:
+    state = load_state()
+    for page, idx, link in get_post_links(max_pages=MAX_PAGES, start_page=state["page"], start_index=state["index"]):
+        print(f"\n🔗 {link}")
         try:
             data = parse_post(link)
-
             if not data["short_review"] and not data["full_review"]:
-                print("⚠️  Skipping: No review content found.\n")
+                print("⚠️  No review content. Skipping.")
                 continue
-
-            # Step 1: Check if it's a review
             review_check = is_film_review(data["title"], data["short_review"])
             print(f"🔎 Review Check: {review_check}")
-
-            if not review_check.lower().startswith("yes"):
-                print("⏭️ Skipping: Not a review post.\n")
-                continue
-
-            # Step 2: Sentiment analysis
-            sentiment = analyze_sentiment(data["full_review"])
-            print(f"🤖 Sentiment: {sentiment}\n")
-
-            # Only keep recommended movies
-            if sentiment.lower().startswith("yes"):
-                curated.append({
-                    "title": data["title"],
-                    "link": link,
-                    "sentiment": sentiment,
-                    "short_review": data["short_review"],
-                    "excerpt": data["full_review"]
-                })
-
-                # Output recommendation immediately
-                print(f"✅ RECOMMENDED")
-                print(f"Title: {data['title']}\n")
-                print(f"Short Review:\n{data['short_review']}\n")
-                print(f"Full Review Excerpt:\n{data['full_review']}\n")
-
+            if review_check.lower().startswith("yes"):
+                save_post(
+                    {
+                        "link": link,
+                        "date": data["date"],
+                        "title": data["title"],
+                        "reviewer": data["reviewer"],
+                        "subtext": data["short_review"],
+                        "full_review": data["full_review"],
+                        "recommendation": None,
+                    }
+                )
         except Exception as e:
             print(f"❌ Error processing {link}: {e}")
+        finally:
+            save_state({"page": page, "index": idx + 1})
 
-    # Final summary
-    print("\n🎯 Curated Recommendations:")
-    for movie in curated:
-        print(f"- {movie['title']} ({movie['sentiment']})")
-        print(f"  {movie['link']}\n")
+
+def analyze_db() -> None:
+    for link, review in fetch_unanalyzed():
+        try:
+            sentiment = analyze_sentiment(review)
+            update_recommendation(link, sentiment)
+            print(f"🤖 Sentiment for {link}: {sentiment}")
+        except Exception as e:
+            print(f"❌ Sentiment failed for {link}: {e}")
+
+
+def main() -> None:
+    init_db()
+    crawl_and_store()
+    analyze_db()
+
 
 if __name__ == "__main__":
     main()
+

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,70 @@
+import sqlite3
+from typing import Dict, List, Tuple
+
+DB_PATH = "reviews.db"
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS posts (
+            link TEXT PRIMARY KEY,
+            date TEXT,
+            title TEXT,
+            reviewer TEXT,
+            subtext TEXT,
+            full_review TEXT,
+            recommendation TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_post(post: Dict[str, str], db_path: str = DB_PATH) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO posts (
+                link,
+                date,
+                title,
+                reviewer,
+                subtext,
+                full_review,
+                recommendation
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                post.get("link"),
+                post.get("date"),
+                post.get("title"),
+                post.get("reviewer"),
+                post.get("subtext"),
+                post.get("full_review"),
+                post.get("recommendation"),
+            ),
+        )
+        conn.commit()
+
+
+def update_recommendation(link: str, recommendation: str, db_path: str = DB_PATH) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE posts SET recommendation=? WHERE link=?",
+            (recommendation, link),
+        )
+        conn.commit()
+
+
+def fetch_unanalyzed(db_path: str = DB_PATH) -> List[Tuple[str, str]]:
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT link, full_review FROM posts WHERE recommendation IS NULL"
+        )
+        return cur.fetchall()
+

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,0 +1,18 @@
+import json
+from typing import Dict
+
+STATE_FILE = "state.json"
+
+
+def load_state() -> Dict[str, int]:
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"page": 1, "index": 0}
+
+
+def save_state(state: Dict[str, int]) -> None:
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+


### PR DESCRIPTION
## Summary
- refactor fetch_links to support resuming from a specific page and link
- parse post date and join full review paragraphs
- clean up OpenAI wrapper to remove duplicate code
- add SQLite database helper and state management utilities
- crawl posts, store to DB, and run sentiment analysis in main
- **add reviewer field in database and parser**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859992eccdc8324bb8bb0e2d8868347