### PR TITLE
Fix openai_wrapper string syntax

### DIFF
--- a/llm/openai_wrapper.py
+++ b/llm/openai_wrapper.py
@@ -8,7 +8,7 @@ client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 def is_film_review(title: str, short_review: str) -> str:
     """Return 'Yes' or 'No' along with a short explanation."""
-    prompt = f"""
+    prompt = f'''
 Given the following blog post metadata:
 
 Title:
@@ -19,7 +19,7 @@ Short Review Snippet:
 
 Does this appear to be a film review?
 Reply with Yes or No, followed by a one-line reason.
-"""
+'''
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],
@@ -29,7 +29,7 @@ Reply with Yes or No, followed by a one-line reason.
 
 def analyze_sentiment(title: str, subtext: str) -> str:
     """Return whether the reviewer recommends the movie as Yes, No or Maybe."""
-    prompt = f"""
+    prompt = f'''
 You are an expert assistant analysing film reviews from the blog
 baradwajrangan.wordpress.com. Some posts on this site are not
 actual movie reviews while others, like the one on "DNA" by Nelson,
@@ -48,7 +48,7 @@ Look for sarcasm or negative phrasing.
 If the snippet does not appear to actually contain a movie review,
 reply with "No – not a review".
 Otherwise answer "Yes", "No" or "Maybe" followed by a concise reason.
-"""
+'''
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": prompt}],


### PR DESCRIPTION
## Summary
- escape nested triple quotes in prompt strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599dd1d59c832497b46bfa496ecb61