### PR TITLE
Improve error handling and logging

### DIFF
--- a/backend/collate_links_async.py
+++ b/backend/collate_links_async.py
@@ -41,7 +41,7 @@ async def crawl_blog_links():
             res = requests.get(link, timeout=10)
             res.raise_for_status()
             extracted_text = parse_post(link)
-            print(extracted_text)
+            logger.debug("Parsed post data: %s", extracted_text)
 
             if not extracted_text:
                 logger.warning("No content extracted from %s", link)

--- a/backend/main.py
+++ b/backend/main.py
@@ -89,7 +89,7 @@ def crawl_and_store() -> None:
             logger.error("Error processing %s: %s", link, e)
 
 def main():
-    print("🎬 Starting Movie Review Miner...\n")
+    logger.info("\U0001F3AC Starting Movie Review Miner...")
     crawl_and_store()
 
 

--- a/backend/new_main.py
+++ b/backend/new_main.py
@@ -1,9 +1,9 @@
 """Utility script for enriching reviews with TMDb metadata."""
 
 import os
-from supabase import create_client
 import requests
 from dotenv import load_dotenv
+from supabase import create_client
 
 from utils.logger import get_logger
 
@@ -12,22 +12,8 @@ load_dotenv()
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 TMDB_API_KEY = os.getenv("TMDB_API_KEY")
-TMDB_BEARER_TOKEN = os.getenv("TMDB_BEARER_TOKEN")
 TMDB_BASE_URL = "https://api.themoviedb.org/3"
 
-
-# Create a Supabase client using the service role key so we can update rows
-supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
-
-def fetch_unenriched_reviews():
-    """Return reviews that have not yet been enriched with TMDb data."""
-    response = (
-        supabase
-        .table("reviews")
-        .select("id, movie_title")
-        .execute()
-    )
-    return response.data
 logger = get_logger(__name__)
 
 try:
@@ -36,11 +22,12 @@ except Exception as e:
     logger.error("Failed to create Supabase client: %s", e)
     raise
 
+
 def fetch_unenriched_reviews():
+    """Return reviews that have not yet been enriched with TMDb data."""
     try:
         response = (
-            supabase
-            .table("reviews")
+            supabase.table("reviews")
             .select("id, movie_title")
             .execute()
         )
@@ -51,20 +38,14 @@ def fetch_unenriched_reviews():
 
 
 def search_tmdb(movie_title: str) -> dict | None:
-    """Search TMDb for movie metadata by title using v4 Bearer token."""
-    url = "https://api.themoviedb.org/3/search/movie"
+    """Search TMDb for movie metadata by title."""
+    url = f"{TMDB_BASE_URL}/search/movie"
     headers = {
-        "Authorization": f"Bearer {os.getenv('TMDB_API_KEY')}",
-        "Content-Type": "application/json;charset=utf-8"
+        "Authorization": f"Bearer {TMDB_API_KEY}",
+        "Content-Type": "application/json;charset=utf-8",
     }
     params = {"query": movie_title}
 
-    # Query the TMDb API for the movie
-    response = requests.get(url, headers=headers, params=params)
-
-    if response.status_code != 200:
-        # Non-200 responses indicate an issue with the API call
-        print(f"❌ Skipped {movie_title}: TMDb API error {response.status_code}: {response.text}")
     try:
         response = requests.get(url, headers=headers, params=params, timeout=10)
         response.raise_for_status()
@@ -81,46 +62,42 @@ def search_tmdb(movie_title: str) -> dict | None:
     return {
         "release_year": top_result.get("release_date", "")[:4],
         "language": top_result.get("original_language", ""),
-        "genre_ids": ", ".join([g["name"] for g in data.get("genres", [])])
+        "genre_ids": top_result.get("genre_ids", []),
     }
 
-def update_metadata(record_id, metadata):
+
+def update_metadata(record_id: str, metadata: dict) -> None:
     """Persist TMDb metadata to the ``reviews`` table."""
-
     update = {
-        # Normalise release date to just the year
-        "release_year": metadata.get("release_date", "")[:4] or None,
-        "language": metadata.get("original_language"),
-        # Store genres as a comma separated list for simplicity
-        "genre": ", ".join(str(genre_id) for genre_id in metadata.get("genre_ids", []))
+        "release_year": metadata.get("release_year") or None,
+        "language": metadata.get("language"),
+        "genre": ", ".join(str(g) for g in metadata.get("genre_ids", [])),
     }
-    # Update the record in Supabase
-    supabase.table("reviews").update(update).eq("id", record_id).execute()
     try:
         supabase.table("reviews").update(update).eq("id", record_id).execute()
     except Exception as e:
         logger.error("Failed to update metadata for %s: %s", record_id, e)
 
+
 def main():
     """Entry point: enrich all reviews missing TMDb data."""
-
     reviews = fetch_unenriched_reviews()
     logger.info("Found %s unenriched reviews", len(reviews))
 
     for review in reviews:
+        movie_title = review.get("movie_title")
         try:
-            print(f"🎞 Processing: {review['movie_title']}...")
-            # Fetch metadata for this movie title from TMDb
-            metadata = search_tmdb(review['movie_title'])
-            print(metadata)
-            # Persist the fetched metadata back to Supabase
-            logger.info("Processing: %s", review['movie_title'])
-            metadata = search_tmdb(review['movie_title'])
+            logger.info("Processing: %s", movie_title)
+            metadata = search_tmdb(movie_title)
             logger.debug("Metadata: %s", metadata)
-            update_metadata(review['id'], metadata)
-            logger.info("Updated Supabase for %s", review['movie_title'])
+            if metadata:
+                update_metadata(review["id"], metadata)
+                logger.info("Updated Supabase for %s", movie_title)
+            else:
+                logger.warning("No metadata found for %s", movie_title)
         except Exception as e:
-            logger.error("Skipped %s: %s", review.get('movie_title'), e)
+            logger.error("Skipped %s: %s", movie_title, e)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/tests/tmdb_metadata.py
+++ b/backend/tests/tmdb_metadata.py
@@ -2,9 +2,11 @@
 
 import os
 import requests
+from utils.logger import get_logger
 
 TMDB_API_KEY = os.getenv("TMDB_API_KEY")
 TMDB_API_URL = "https://api.themoviedb.org/3"
+logger = get_logger(__name__)
 
 def get_movie_metadata(movie_title):
     if not TMDB_API_KEY:
@@ -36,5 +38,5 @@ def get_movie_metadata(movie_title):
             "title": movie.get("title"),
         }
     except Exception as e:
-        print(f"❌ TMDb metadata fetch failed for '{movie_title}': {e}")
+        logger.error("TMDb metadata fetch failed for '%s': %s", movie_title, e)
         return {}


### PR DESCRIPTION
## Summary
- replace prints with logging
- ensure Supabase and TMDb utilities log errors properly
- clean up new_main script and add logging
- ensure tests use logging as well

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae4c8ff988324bddb51d81d41782b