### PR TITLE
Add progress bars across pipeline steps

### DIFF
--- a/backend/pipeline/step_2_parse_posts.py
+++ b/backend/pipeline/step_2_parse_posts.py
@@ -2,6 +2,7 @@
 import asyncio
 import aiohttp
 import async_timeout
+from tqdm.asyncio import tqdm
 from crawler.parse_post import parse_post_async
 from db.store_review import store_review_if_missing
 from utils.logger import get_logger
@@ -41,4 +42,5 @@ async def parse_posts(urls: list[str]) -> None:
         return
     async with aiohttp.ClientSession() as session:
         tasks = [_parse_and_store(session, url) for url in urls]
-        await asyncio.gather(*tasks)
+        for task in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
+            await task

--- a/backend/pipeline/step_3_classify_reviews.py
+++ b/backend/pipeline/step_3_classify_reviews.py
@@ -2,6 +2,7 @@
 from db.review_queries import get_unclassified_reviews, update_is_film_review
 from llm.openai_wrapper import is_film_review
 from utils.logger import get_logger
+from tqdm import tqdm
 
 logger = get_logger(__name__)
 
@@ -10,7 +11,7 @@ def classify_reviews() -> None:
     reviews = get_unclassified_reviews()
     logger.info("Classifying %s reviews", len(reviews))
 
-    for review in reviews:
+    for review in tqdm(reviews):
         try:
             result = is_film_review(review.get("blog_title", ""), review.get("short_review", ""))
             update_is_film_review(review["id"], bool(result))

--- a/backend/pipeline/step_4_link_movies.py
+++ b/backend/pipeline/step_4_link_movies.py
@@ -3,6 +3,7 @@ from db.review_queries import get_unenriched_links, update_review_with_movie_id
 from db.movie_queries import get_movie_by_title, create_movie
 from llm.openai_wrapper import extract_movie_title
 from utils.logger import get_logger
+from tqdm import tqdm
 
 logger = get_logger(__name__)
 
@@ -11,7 +12,7 @@ def link_movies() -> None:
     reviews = get_unenriched_links()
     logger.info("Linking movies for %s reviews", len(reviews))
 
-    for review in reviews:
+    for review in tqdm(reviews):
         try:
             title = extract_movie_title(review.get("blog_title", ""))
             if not title or title.lower() == "none":

--- a/backend/pipeline/step_5_generate_sentiment.py
+++ b/backend/pipeline/step_5_generate_sentiment.py
@@ -2,6 +2,7 @@
 from db.review_queries import get_reviews_missing_sentiment, update_sentiment_for_review
 from llm.openai_wrapper import analyze_sentiment
 from utils.logger import get_logger
+from tqdm import tqdm
 
 logger = get_logger(__name__)
 
@@ -10,7 +11,7 @@ def generate_sentiment() -> None:
     reviews = get_reviews_missing_sentiment()
     logger.info("Generating sentiment for %s reviews", len(reviews))
 
-    for review in reviews:
+    for review in tqdm(reviews):
         try:
             sentiment = analyze_sentiment(review.get("blog_title", ""), review.get("short_review", ""))
             if sentiment:

--- a/backend/pipeline/step_6_enrich_metadata.py
+++ b/backend/pipeline/step_6_enrich_metadata.py
@@ -3,6 +3,7 @@ import asyncio
 from db.movie_queries import get_movies_missing_metadata, update_movie_metadata
 from tmdb.tmdb_api import search_tmdb
 from utils.logger import get_logger
+from tqdm import tqdm
 
 logger = get_logger(__name__)
 
@@ -11,7 +12,7 @@ async def enrich_metadata() -> None:
     movies = get_movies_missing_metadata()
     logger.info("Enriching metadata for %s movies", len(movies))
 
-    for movie in movies:
+    for movie in tqdm(movies):
         try:
             metadata = await search_tmdb(movie["title"])
             if metadata:


### PR DESCRIPTION
## Summary
- integrate tqdm-based progress bars in page fetching and all pipeline steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce4f5d9708324bbcf9d5518f2e369