### PR TITLE
Improve pipeline logging and failure handling

### DIFF
--- a/backend/crawler/fetch_links.py
+++ b/backend/crawler/fetch_links.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 
 BASE_URL = "https://baradwajrangan.wordpress.com"
 CONCURRENT_FETCHES = 10
@@ -70,6 +71,7 @@ async def fetch_listing_page(session: aiohttp.ClientSession, page: int) -> list[
             await asyncio.sleep(2 ** (attempt - 1))
 
     logger.error("Giving up on page %s after %s retries", page, MAX_RETRIES)
+    write_failure("failed_pages.txt", str(page), "max retries")
     return []
 
 

--- a/backend/pipeline/step_2_parse_posts.py
+++ b/backend/pipeline/step_2_parse_posts.py
@@ -6,6 +6,7 @@ from tqdm.asyncio import tqdm
 from crawler.parse_post import parse_post_async
 from db.store_review import store_review_if_missing
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 
 logger = get_logger(__name__)
 
@@ -33,9 +34,8 @@ async def _parse_and_store(session: aiohttp.ClientSession, url: str) -> None:
         except Exception as e:
             logger.warning("Attempt %s failed for %s: %s", attempt, url, e)
             await asyncio.sleep(2 ** (attempt - 1))
-    logger.error("Failed to parse %s", url)
-    with open("failed_post_links.txt", "a") as f:
-        f.write(f"{url}\n")
+    logger.error("Failed to parse %s", url, exc_info=True)
+    write_failure("failed_post_links.txt", url, "max retries")
 
 async def parse_posts(urls: list[str]) -> None:
     """Parse and store a list of blog post URLs."""

--- a/backend/pipeline/step_3_classify_reviews.py
+++ b/backend/pipeline/step_3_classify_reviews.py
@@ -2,6 +2,7 @@
 from db.review_queries import get_unclassified_reviews, update_is_film_review
 from llm.openai_wrapper import is_film_review
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 from tqdm import tqdm
 
 logger = get_logger(__name__)
@@ -17,4 +18,7 @@ def classify_reviews() -> None:
             update_is_film_review(review["id"], bool(result))
             logger.info("Updated review %s -> %s", review["id"], result)
         except Exception as e:
-            logger.error("Failed classification for %s: %s", review.get("id"), e)
+            logger.error(
+                "Failed classification for %s: %s", review.get("id"), e, exc_info=True
+            )
+            write_failure("failed_classifications.txt", str(review.get("id")), e)

--- a/backend/pipeline/step_4_link_movies.py
+++ b/backend/pipeline/step_4_link_movies.py
@@ -3,6 +3,7 @@ from db.review_queries import get_unenriched_links, update_review_with_movie_id
 from db.movie_queries import get_movie_by_title, create_movie
 from llm.openai_wrapper import extract_movie_title
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 from tqdm import tqdm
 
 logger = get_logger(__name__)
@@ -24,7 +25,10 @@ def link_movies() -> None:
             update_review_with_movie_id(review["id"], movie_id)
             logger.info("Linked review %s -> movie %s", review["id"], title)
         except Exception as e:
-            logger.error("Movie link failed for %s: %s", review.get("id"), e)
+            logger.error(
+                "Movie link failed for %s: %s", review.get("id"), e, exc_info=True
+            )
+            write_failure("failed_movie_linking.txt", str(review.get("id")), e)
 
 if __name__ == "__main__":
     import warnings

--- a/backend/pipeline/step_5_generate_sentiment.py
+++ b/backend/pipeline/step_5_generate_sentiment.py
@@ -2,6 +2,7 @@
 from db.review_queries import get_reviews_missing_sentiment, update_sentiment_for_review
 from llm.openai_wrapper import analyze_sentiment
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 from tqdm import tqdm
 
 logger = get_logger(__name__)
@@ -20,4 +21,7 @@ def generate_sentiment() -> None:
             else:
                 logger.warning("No sentiment returned for review %s", review["id"])
         except Exception as e:
-            logger.error("Sentiment analysis failed for %s: %s", review.get("id"), e)
+            logger.error(
+                "Sentiment analysis failed for %s: %s", review.get("id"), e, exc_info=True
+            )
+            write_failure("failed_sentiment.txt", str(review.get("id")), e)

--- a/backend/pipeline/step_6_enrich_metadata.py
+++ b/backend/pipeline/step_6_enrich_metadata.py
@@ -3,6 +3,7 @@ import asyncio
 from db.movie_queries import get_movies_missing_metadata, update_movie_metadata
 from tmdb.tmdb_api import search_tmdb
 from utils.logger import get_logger
+from utils.io_helpers import write_failure
 from tqdm import tqdm
 
 logger = get_logger(__name__)
@@ -20,7 +21,10 @@ async def _enrich_movie(movie: dict) -> None:
         else:
             logger.warning("No metadata found for %s", movie["title"])
     except Exception as e:
-        logger.error("TMDb enrichment failed for %s: %s", movie.get("title"), e)
+        logger.error(
+            "TMDb enrichment failed for %s: %s", movie.get("title"), e, exc_info=True
+        )
+        write_failure("failed_tmdb.txt", movie.get("title", ""), e)
 
 
 async def enrich_metadata() -> None:

--- a/backend/run_pipeline.py
+++ b/backend/run_pipeline.py
@@ -1,4 +1,5 @@
 """Orchestrate the weekly enrichment pipeline."""
+import argparse
 import asyncio
 from pipeline import (
     step_1_fetch_links,
@@ -12,9 +13,17 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-async def main() -> None:
+async def main(limit: int | None = None, dry_run: bool = False) -> None:
     logger.info("Starting pipeline run")
     links = await step_1_fetch_links.fetch_links()
+    if limit:
+        links = links[:limit]
+        logger.debug("Limiting to %s links", limit)
+
+    if dry_run:
+        logger.info("Dry run enabled - exiting early")
+        return
+
     await step_2_parse_posts.parse_posts(links)
     step_3_classify_reviews.classify_reviews()
     step_4_link_movies.link_movies()
@@ -23,4 +32,9 @@ async def main() -> None:
     logger.info("Pipeline run complete")
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description="Run enrichment pipeline")
+    parser.add_argument("--limit", type=int, help="Limit number of links to process")
+    parser.add_argument("--dry-run", action="store_true", help="Run fetch step only")
+    args = parser.parse_args()
+
+    asyncio.run(main(limit=args.limit, dry_run=args.dry_run))

--- a/backend/utils/io_helpers.py
+++ b/backend/utils/io_helpers.py
@@ -1,2 +1,11 @@
-"""Placeholder for future file I/O utility functions."""
+"""File I/O helper utilities."""
+
+from pathlib import Path
+
+
+def write_failure(path: str, item: str, error: Exception | str) -> None:
+    """Append a failed item to the given file for later retry."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(f"{item} | {error}\n")
 

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -1,14 +1,46 @@
-"""Simple helper for creating consistent loggers across modules."""
+"""Shared logging utilities."""
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from pathlib import Path
+
+_INITIALISED = False
+
+
+def _initialise() -> None:
+    """Configure the root logger on first use."""
+    global _INITIALISED
+    if _INITIALISED:
+        return
+
+    log_dir = Path("logs")
+    log_dir.mkdir(exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    log_file = log_dir / f"{timestamp}.log"
+
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+    )
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(formatter)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)
+
+    _INITIALISED = True
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Return a logger configured with basic settings."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-    )
+    """Return a module-specific logger with shared configuration."""
+    if not _INITIALISED:
+        _initialise()
     return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- implement timestamped run log files via new logger util
- add generic `write_failure` helper and use it across pipeline steps
- record failures from crawling, parsing, classification, linking, sentiment and TMDb enrichment
- allow `run_pipeline.py` to limit work or do a dry run

## Testing
- `pytest -q`
- `python backend/run_pipeline.py --dry-run --limit 1` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_685d771d12f8832490fc3ee8b6e04f9f