### PR TITLE
Add StepLogger for pipeline metrics

### DIFF
--- a/backend/pipeline/step_3_classify_reviews.py
+++ b/backend/pipeline/step_3_classify_reviews.py
@@ -1,29 +1,37 @@
 """Step 3: classify parsed posts as film reviews."""
 from db.review_queries import get_unclassified_reviews, update_is_film_review
 from llm.openai_wrapper import is_film_review
-from utils.logger import get_logger
 from utils.io_helpers import write_failure
+from utils import StepLogger
 from tqdm import tqdm
 
-logger = get_logger(__name__)
 
 def classify_reviews() -> None:
     """Classify stored reviews as film reviews or not."""
+    step_logger = StepLogger("step_3_classify_reviews")
     reviews = get_unclassified_reviews()
-    logger.info("Classifying %s reviews", len(reviews))
+    step_logger.metrics["input_count"] = len(reviews)
+    step_logger.logger.info("Classifying %s reviews", len(reviews))
 
     for review in tqdm(reviews):
+        step_logger.metrics["processed_count"] += 1
         try:
-            result = is_film_review(review.get("blog_title", ""), review.get("short_review", ""))
+            result = is_film_review(
+                review.get("blog_title", ""), review.get("short_review", "")
+            )
             update_is_film_review(review["id"], bool(result))
-            logger.info("Updated review %s -> %s", review["id"], result)
+            step_logger.metrics["saved_count"] += 1
+            step_logger.logger.info("Updated review %s -> %s", review["id"], result)
         except Exception as e:
-            logger.error(
+            step_logger.metrics["failed_count"] += 1
+            step_logger.logger.error(
                 "Failed classification for %s: %s", review.get("id"), e, exc_info=True
             )
             write_failure("failed_classifications.txt", str(review.get("id")), e)
+    step_logger.finalize()
+
 
 if __name__ == "__main__":
     import warnings
-    warnings.filterwarnings("ignore", category=RuntimeWarning)  
+    warnings.filterwarnings("ignore", category=RuntimeWarning)
     classify_reviews()

--- a/backend/pipeline/step_4_link_movies.py
+++ b/backend/pipeline/step_4_link_movies.py
@@ -2,33 +2,40 @@
 from db.review_queries import get_links_without_movieid, update_review_with_movie_id
 from db.movie_queries import get_movie_by_title, create_movie
 from llm.openai_wrapper import extract_movie_title
-from utils.logger import get_logger
 from utils.io_helpers import write_failure
+from utils import StepLogger
 from tqdm import tqdm
-
-logger = get_logger(__name__)
 
 def link_movies() -> None:
     """Extract movie titles for reviews and link them to movie records."""
+    step_logger = StepLogger("step_4_link_movies")
     reviews = get_links_without_movieid()
-    logger.info("Linking movies for %s reviews", len(reviews))
+    step_logger.metrics["input_count"] = len(reviews)
+    step_logger.logger.info("Linking movies for %s reviews", len(reviews))
 
     for review in tqdm(reviews):
         try:
             title = extract_movie_title(review.get("blog_title", ""))
             if not title or title.lower() == "none":
-                logger.info("No movie title found for review %s", review.get("id"))
+                step_logger.logger.info(
+                    "No movie title found for review %s", review.get("id")
+                )
                 continue
 
             movie = get_movie_by_title(title)
             movie_id = movie["id"] if movie else create_movie(title)
             update_review_with_movie_id(review["id"], movie_id)
-            logger.info("Linked review %s -> movie %s", review["id"], title)
+            step_logger.metrics["saved_count"] += 1
+            step_logger.logger.info("Linked review %s -> movie %s", review["id"], title)
         except Exception as e:
-            logger.error(
+            step_logger.metrics["failed_count"] += 1
+            step_logger.logger.error(
                 "Movie link failed for %s: %s", review.get("id"), e, exc_info=True
             )
             write_failure("failed_movie_linking.txt", str(review.get("id")), e)
+        finally:
+            step_logger.metrics["processed_count"] += 1
+    step_logger.finalize()
 
 if __name__ == "__main__":
     import warnings

--- a/backend/pipeline/step_6_enrich_metadata.py
+++ b/backend/pipeline/step_6_enrich_metadata.py
@@ -3,26 +3,26 @@ import asyncio
 from db.movie_queries import get_movies_missing_metadata, update_movie_metadata
 from db.review_queries import get_post_date_for_movie
 from tmdb.tmdb_api import search_tmdb
-from utils.logger import get_logger
 from utils.io_helpers import write_failure
+from utils import StepLogger
 from tqdm import tqdm
-
-logger = get_logger(__name__)
 
 CONCURRENT_REQUESTS = 5
 semaphore = asyncio.Semaphore(CONCURRENT_REQUESTS)
 
-async def _enrich_movie(movie: dict) -> None:
+async def _enrich_movie(movie: dict, step_logger: StepLogger) -> None:
     try:
         async with semaphore:
             metadata = await search_tmdb(movie["title"], movie["review_year"])
         if metadata:
             update_movie_metadata(movie["id"], metadata)
-            logger.info("Updated metadata for %s", movie["title"])
+            step_logger.metrics["saved_count"] += 1
+            step_logger.logger.info("Updated metadata for %s", movie["title"])
         else:
-            logger.warning("No metadata found for %s", movie["title"])
+            step_logger.logger.warning("No metadata found for %s", movie["title"])
     except Exception as e:
-        logger.error(
+        step_logger.metrics["failed_count"] += 1
+        step_logger.logger.error(
             "TMDb enrichment failed for %s: %s", movie.get("title"), e, exc_info=True
         )
         write_failure("failed_tmdb.txt", movie.get("title", ""), e)
@@ -30,13 +30,16 @@ async def _enrich_movie(movie: dict) -> None:
 
 async def enrich_metadata() -> None:
     """Fill in metadata for movies lacking it using TMDb."""
+    step_logger = StepLogger("step_6_enrich_metadata")
     movies = get_movies_missing_metadata()
-    logger.info("Enriching metadata for %s movies", len(movies))
+    step_logger.metrics["input_count"] = len(movies)
+    step_logger.logger.info("Enriching metadata for %s movies", len(movies))
 
-
-    tasks = [_enrich_movie(movie) for movie in movies]
+    tasks = [_enrich_movie(movie, step_logger) for movie in movies]
     await asyncio.gather(*tasks, return_exceptions=True)
-    logger.info("Metadata enrichment complete")
+    step_logger.metrics["processed_count"] = step_logger.metrics["saved_count"] + step_logger.metrics["failed_count"]
+    step_logger.logger.info("Metadata enrichment complete")
+    step_logger.finalize()
 
 if __name__ == "__main__":
     import warnings

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+from .step_logger import StepLogger

--- a/backend/utils/step_logger.py
+++ b/backend/utils/step_logger.py
@@ -1,0 +1,45 @@
+import json
+import logging
+from pathlib import Path
+from utils.logger import get_logger
+
+class StepLogger:
+    """Helper to log per-step metrics and summary."""
+
+    def __init__(self, step_name: str) -> None:
+        self.step_name = step_name
+        self.logger = get_logger(step_name)
+        self.metrics = {
+            "step": step_name,
+            "input_count": 0,
+            "processed_count": 0,
+            "saved_count": 0,
+            "failed_count": 0,
+            "notes": [],
+        }
+        step_log = Path("logs") / f"{step_name}.log"
+        step_log.parent.mkdir(parents=True, exist_ok=True)
+        handler = logging.FileHandler(step_log)
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+        )
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
+        self._handler = handler
+
+    def add_note(self, note: str) -> None:
+        self.metrics["notes"].append(note)
+
+    def finalize(self) -> None:
+        """Append metrics to the pipeline summary file and close handler."""
+        summary_path = Path("logs") / "pipeline_summary.json"
+        if summary_path.exists():
+            with open(summary_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        else:
+            data = []
+        data.append(self.metrics)
+        with open(summary_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        self.logger.removeHandler(self._handler)
+        self._handler.close()


### PR DESCRIPTION
## Summary
- implement `StepLogger` utility for per-step logging and pipeline summaries
- expose `StepLogger` in utils
- instrument each pipeline step script to use `StepLogger`

## Testing
- `python -m py_compile backend/utils/step_logger.py backend/pipeline/step_1_fetch_links.py backend/pipeline/step_2_parse_posts.py backend/pipeline/step_3_classify_reviews.py backend/pipeline/step_4_link_movies.py backend/pipeline/step_5_generate_sentiment.py backend/pipeline/step_6_enrich_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_685dcf219c4483248edc19b1e1d7e4c5