### PR TITLE
Add pipeline logging to Supabase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Guidelines
+
+To log pipeline step outcomes to Supabase, use `backend/db/pipeline_logger.py`.
+Insert one row per run with fields:
+- `step_name`
+- `link_id`
+- `movie_id`
+- `attempt_number`
+- `status` (`"success"` or `"failure"`)
+- `result_data` or `error_message`
+- `timestamp` (defaults to `now()`)
+
+Use the `log_step_result` helper to perform the insert and avoid duplicates.

--- a/backend/db/pipeline_logger.py
+++ b/backend/db/pipeline_logger.py
@@ -1,0 +1,46 @@
+"""Log pipeline step outcomes to Supabase."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from db.supabase_client import supabase
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def log_step_result(
+    step_name: str,
+    *,
+    link_id: str | None = None,
+    movie_id: str | None = None,
+    attempt_number: int = 1,
+    status: str,
+    result_data: dict[str, Any] | None = None,
+    error_message: str | None = None,
+    timestamp: datetime | None = None,
+) -> None:
+    """Insert a pipeline step result into the ``pipeline_logs`` table."""
+    data: dict[str, Any] = {
+        "step_name": step_name,
+        "attempt_number": attempt_number,
+        "status": status,
+    }
+    if link_id is not None:
+        data["link_id"] = link_id
+    if movie_id is not None:
+        data["movie_id"] = movie_id
+    if timestamp:
+        data["created_at"] = timestamp.isoformat()
+    if result_data is not None:
+        data["result_data"] = result_data
+    if error_message is not None:
+        data["error_message"] = error_message
+
+    try:
+        logger.debug("Logging pipeline step: %s", data)
+        supabase.table("pipeline_logs").insert(data).execute()
+    except Exception as e:
+        logger.error("Failed to insert pipeline log: %s", e)

--- a/backend/pipeline/step_3_classify_reviews.py
+++ b/backend/pipeline/step_3_classify_reviews.py
@@ -3,6 +3,7 @@ from db.review_queries import get_unclassified_reviews, update_is_film_review
 from llm.openai_wrapper import is_film_review
 from utils.io_helpers import write_failure
 from utils import StepLogger
+from db.pipeline_logger import log_step_result
 from tqdm import tqdm
 
 
@@ -21,13 +22,29 @@ def classify_reviews() -> None:
             )
             update_is_film_review(review["id"], bool(result))
             step_logger.metrics["saved_count"] += 1
-            step_logger.logger.info("Updated review %s -> %s", review["id"], result)
+            step_logger.logger.info(
+                "Updated review %s -> %s", review["id"], result
+            )
+            log_step_result(
+                "classify_review",
+                link_id=review.get("id"),
+                attempt_number=1,
+                status="success",
+                result_data={"is_film_review": bool(result)},
+            )
         except Exception as e:
             step_logger.metrics["failed_count"] += 1
             step_logger.logger.error(
                 "Failed classification for %s: %s", review.get("id"), e, exc_info=True
             )
             write_failure("failed_classifications.txt", str(review.get("id")), e)
+            log_step_result(
+                "classify_review",
+                link_id=review.get("id"),
+                attempt_number=1,
+                status="failure",
+                error_message=str(e),
+            )
     step_logger.finalize()
 
 

--- a/backend/pipeline/step_6_enrich_metadata.py
+++ b/backend/pipeline/step_6_enrich_metadata.py
@@ -5,6 +5,7 @@ from db.review_queries import get_post_date_for_movie
 from tmdb.tmdb_api import search_tmdb
 from utils.io_helpers import write_failure
 from utils import StepLogger
+from db.pipeline_logger import log_step_result
 from tqdm import tqdm
 
 CONCURRENT_REQUESTS = 5
@@ -18,14 +19,34 @@ async def _enrich_movie(movie: dict, step_logger: StepLogger) -> None:
             update_movie_metadata(movie["id"], metadata)
             step_logger.metrics["saved_count"] += 1
             step_logger.logger.info("Updated metadata for %s", movie["title"])
+            log_step_result(
+                "enrich_metadata",
+                movie_id=movie.get("id"),
+                attempt_number=1,
+                status="success",
+            )
         else:
             step_logger.logger.warning("No metadata found for %s", movie["title"])
+            log_step_result(
+                "enrich_metadata",
+                movie_id=movie.get("id"),
+                attempt_number=1,
+                status="failure",
+                error_message="No metadata",
+            )
     except Exception as e:
         step_logger.metrics["failed_count"] += 1
         step_logger.logger.error(
             "TMDb enrichment failed for %s: %s", movie.get("title"), e, exc_info=True
         )
         write_failure("failed_tmdb.txt", movie.get("title", ""), e)
+        log_step_result(
+            "enrich_metadata",
+            movie_id=movie.get("id"),
+            attempt_number=1,
+            status="failure",
+            error_message=str(e),
+        )
 
 
 async def enrich_metadata() -> None:

--- a/backend/utils/step_logger.py
+++ b/backend/utils/step_logger.py
@@ -2,6 +2,7 @@ import json
 import logging
 from pathlib import Path
 from utils.logger import get_logger
+from db.pipeline_logger import log_step_result
 
 class StepLogger:
     """Helper to log per-step metrics and summary."""
@@ -41,5 +42,14 @@ class StepLogger:
         data.append(self.metrics)
         with open(summary_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
+        try:
+            log_step_result(
+                self.step_name,
+                attempt_number=1,
+                status="success",
+                result_data=self.metrics,
+            )
+        except Exception as e:  # noqa: BLE001
+            self.logger.error("Failed to log step summary: %s", e)
         self.logger.removeHandler(self._handler)
         self._handler.close()


### PR DESCRIPTION
## Summary
- add instructions in `AGENTS.md` about logging pipeline steps
- implement `log_step_result` helper for Supabase
- hook pipeline steps and `StepLogger` to record results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e037377848324abe32205eefde9fd