### PR TITLE
Refactor parsing step with retry helper

### DIFF
--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -1,0 +1,48 @@
+"""Async CRUD helpers for Supabase."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .supabase_client import supabase
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def upsert_review(review: dict[str, Any]) -> None:
+    """Insert or update a review row."""
+    try:
+        supabase.table("reviews").upsert(review, on_conflict="link").execute()
+    except Exception as e:
+        logger.error("Failed to upsert review: %s", e)
+        raise
+
+
+async def get_or_create_movie(title: str) -> str:
+    """Return movie id for title, creating the movie if needed."""
+    try:
+        res = supabase.table("movies").select("id").eq("title", title).limit(1).execute()
+        if res.data:
+            return res.data[0]["id"]
+        insert = supabase.table("movies").insert({"title": title}).execute()
+        return insert.data[0]["id"]
+    except Exception as e:
+        logger.error("get_or_create_movie failed for '%s': %s", title, e)
+        raise
+
+
+async def update_review_sentiment(review_id: str, sentiment: str) -> None:
+    try:
+        supabase.table("reviews").update({"sentiment": sentiment}).eq("id", review_id).execute()
+    except Exception as e:
+        logger.error("Failed to update sentiment for %s: %s", review_id, e)
+        raise
+
+
+async def update_movie_metadata(movie_id: str, data: dict[str, Any]) -> None:
+    try:
+        supabase.table("movies").update(data).eq("id", movie_id).execute()
+    except Exception as e:
+        logger.error("Failed to update movie metadata for %s: %s", movie_id, e)
+        raise

--- a/backend/tests/test_retries.py
+++ b/backend/tests/test_retries.py
@@ -1,0 +1,49 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+ROOT = Path(__file__).resolve().parents[1]
+
+fake_utils = types.ModuleType("utils")
+fake_logger = types.ModuleType("logger")
+
+def dummy_get_logger(name: str):
+    import logging
+    return logging.getLogger(name)
+
+fake_logger.get_logger = dummy_get_logger
+fake_utils.logger = fake_logger
+sys.modules["utils"] = fake_utils
+sys.modules["utils.logger"] = fake_logger
+
+spec = importlib.util.spec_from_file_location(
+    "retries", ROOT / "utils" / "retries.py"
+)
+retries = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(retries)
+run_with_retries = retries.run_with_retries
+
+
+def test_run_with_retries_success():
+    calls = {"count": 0}
+
+    async def sometimes_fail(attempt: int = 1):
+        calls["count"] += 1
+        if calls["count"] < 2:
+            raise ValueError("boom")
+        return "ok"
+
+    result = asyncio.run(run_with_retries(sometimes_fail, max_retries=3, base_delay=0))
+    assert result == "ok"
+    assert calls["count"] == 2
+
+
+def test_run_with_retries_failure():
+    async def always_fail(attempt: int = 1):
+        raise RuntimeError("nope")
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(run_with_retries(always_fail, max_retries=2, base_delay=0))

--- a/backend/utils/retries.py
+++ b/backend/utils/retries.py
@@ -1,0 +1,36 @@
+import asyncio
+import random
+from typing import Any, Callable, Iterable
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run_with_retries(
+    func: Callable[..., Any],
+    args: Iterable[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+) -> Any:
+    """Run an async function with retries and exponential backoff."""
+
+    if args is None:
+        args = []
+    if kwargs is None:
+        kwargs = {}
+
+    attempt = 1
+    delay = base_delay
+    while True:
+        try:
+            return await func(*args, attempt=attempt, **kwargs)
+        except Exception as err:
+            logger.warning("Attempt %s failed: %s", attempt, err)
+            if attempt >= max_retries:
+                logger.error("Giving up after %s attempts", attempt)
+                raise
+            await asyncio.sleep(delay + random.random() * base_delay)
+            attempt += 1
+            delay *= 2


### PR DESCRIPTION
## Summary
- add an async `run_with_retries` utility
- provide CRUD helpers for Supabase interactions
- refactor `step_2_parse_posts` to use retry helper and stricter validation
- add unit tests for retry logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e09c68d108324a13bb5e703714ed1