### PR TITLE
Add minimal React Native app scaffold

### DIFF
--- a/movie-review-app/App.tsx
+++ b/movie-review-app/App.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './screens/HomeScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ headerShown: false }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/movie-review-app/components/MovieCard.tsx
+++ b/movie-review-app/components/MovieCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, Image } from 'react-native';
+import { Movie } from '../types';
+
+interface Props {
+  movie: Movie;
+}
+
+export default function MovieCard({ movie }: Props) {
+  return (
+    <View className="flex-row bg-white rounded-lg m-2 overflow-hidden">
+      <Image
+        source={{ uri: movie.poster_url }}
+        style={{ width: 80, height: 120 }}
+        resizeMode="cover"
+      />
+      <View className="flex-1 p-2">
+        <Text className="font-bold text-lg">{movie.title}</Text>
+        <Text className="text-sm text-gray-600">{movie.language}</Text>
+        <Text className="text-sm mt-2">{movie.review_summary}</Text>
+      </View>
+    </View>
+  );
+}

--- a/movie-review-app/components/SearchBar.tsx
+++ b/movie-review-app/components/SearchBar.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, TextInput } from 'react-native';
+
+interface Props {
+  onSearch: (text: string) => void;
+}
+
+export default function SearchBar({ onSearch }: Props) {
+  const [query, setQuery] = useState('');
+
+  const handleChange = (text: string) => {
+    setQuery(text);
+    onSearch(text);
+  };
+
+  return (
+    <View className="p-2">
+      <TextInput
+        placeholder="Search movies..."
+        value={query}
+        onChangeText={handleChange}
+        style={{
+          backgroundColor: '#fff',
+          paddingHorizontal: 12,
+          paddingVertical: 8,
+          borderRadius: 8,
+        }}
+      />
+    </View>
+  );
+}

--- a/movie-review-app/components/SuggestionCard.tsx
+++ b/movie-review-app/components/SuggestionCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View, Text, Image } from 'react-native';
+import { Movie } from '../types';
+
+interface Props {
+  movie: Movie | null;
+}
+
+export default function SuggestionCard({ movie }: Props) {
+  if (!movie) return null;
+
+  return (
+    <View className="bg-indigo-100 rounded-lg m-2 p-2">
+      <Text className="font-bold mb-1">Rare Gem</Text>
+      <View className="flex-row items-center">
+        <Image
+          source={{ uri: movie.poster_url }}
+          style={{ width: 60, height: 90, borderRadius: 4 }}
+        />
+        <View className="flex-1 ml-2">
+          <Text className="font-semibold">{movie.title}</Text>
+          <Text className="text-xs text-gray-600">{movie.language}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/movie-review-app/lib/api.ts
+++ b/movie-review-app/lib/api.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabase';
+import { Movie } from '../types';
+
+export async function fetchMovies(query: string = ''): Promise<Movie[]> {
+  let request = supabase
+    .from('movies')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (query) {
+    request = request.textSearch('title', query, { type: 'websearch' });
+  }
+
+  const { data, error } = await request;
+  if (error) {
+    console.error('Error fetching movies', error);
+    return [];
+  }
+  return (data as Movie[]) || [];
+}
+
+export async function fetchRareGem(): Promise<Movie | null> {
+  const { data, error } = await supabase
+    .from('movies')
+    .select('*')
+    .lt('popularity', 30)
+    .gt('sentiment_score', 0.8)
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  if (error) {
+    console.error('Error fetching rare gem', error);
+    return null;
+  }
+
+  if (data && data.length > 0) {
+    const randomIndex = Math.floor(Math.random() * data.length);
+    return data[randomIndex] as Movie;
+  }
+  return null;
+}

--- a/movie-review-app/lib/supabase.ts
+++ b/movie-review-app/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/movie-review-app/screens/HomeScreen.tsx
+++ b/movie-review-app/screens/HomeScreen.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, FlatList, RefreshControl } from 'react-native';
+import SearchBar from '../components/SearchBar';
+import MovieCard from '../components/MovieCard';
+import SuggestionCard from '../components/SuggestionCard';
+import { fetchMovies, fetchRareGem } from '../lib/api';
+import { Movie } from '../types';
+
+export default function HomeScreen() {
+  const [movies, setMovies] = useState<Movie[]>([]);
+  const [rareGem, setRareGem] = useState<Movie | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = async (query = '') => {
+    setRefreshing(true);
+    const result = await fetchMovies(query);
+    setMovies(result);
+    const gem = await fetchRareGem();
+    setRareGem(gem);
+    setRefreshing(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSearch = (text: string) => {
+    load(text);
+  };
+
+  const onRefresh = useCallback(() => {
+    load();
+  }, []);
+
+  return (
+    <View className="flex-1 bg-gray-100">
+      <SearchBar onSearch={handleSearch} />
+      <FlatList
+        data={movies}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <MovieCard movie={item} />}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      />
+      <SuggestionCard movie={rareGem} />
+    </View>
+  );
+}

--- a/movie-review-app/types/index.ts
+++ b/movie-review-app/types/index.ts
@@ -1,0 +1,10 @@
+export interface Movie {
+  id: string;
+  title: string;
+  language: string;
+  poster_url: string;
+  review_summary: string;
+  created_at: string;
+  sentiment_score: number;
+  popularity: number;
+}


### PR DESCRIPTION
## Summary
- add Expo-friendly React Native UI skeleton
- implement SearchBar, MovieCard, SuggestionCard components
- create HomeScreen with Supabase-powered movie list and rare gem feature
- add Supabase helper libraries and types

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_685e118af50483248520040b70deb7e8