### PR TITLE
Add web scaffolding with base styles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Movie Review Miner</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="markdown">
+  <h1>Movie Review Miner</h1>
+  <div class="search">
+    <input type="text" class="ais-SearchBox-input" placeholder="Search movies...">
+  </div>
+  <h3>Example Section</h3>
+  <p>This is a basic scaffolding page for styling.</p>
+  <ol>
+    <li>Sample item 1</li>
+    <li>Sample item 2</li>
+  </ol>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,43 @@
+body {
+  background-color: #ffffff;
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.markdown h1:not([class]) {
+  font-family: 'Poppins', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-top: var(--spacing-scalable-xl, 2rem);
+}
+
+.markdown h3.header-sidebar-hide,
+.markdown h3:not([class]) {
+  font-family: 'Poppins', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-top: var(--spacing-scalable-xl, 1.5rem);
+}
+
+.markdown ol:not([class]),
+.markdown p:not([class]),
+.markdown ul:not([class]) {
+  color: var(--color-text-1, #333);
+  font-family: 'Poppins', sans-serif;
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+.multi-language .tile .lang-native {
+  color: var(--color-text-2, #555);
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.6;
+}
+
+.ais-SearchBox-input {
+  box-shadow: none;
+  padding: 0 2.5rem;
+  font-family: 'Poppins', sans-serif;
+}


### PR DESCRIPTION
## Summary
- add new `web/` folder with `index.html` and `styles.css`
- apply white background and Poppins fonts
- style headings, search box and body elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686883aaf85c8324a3c2273e0c3a8b2d