### PR TITLE
Refactor pipeline stages and crawler

### DIFF
--- a/backend/crawler/fetch_links.py
+++ b/backend/crawler/fetch_links.py
@@ -1,98 +1,13 @@
-import asyncio
-import aiohttp
-import async_timeout
-from tqdm.asyncio import tqdm
-from bs4 import BeautifulSoup
-from urllib.parse import urljoin
+"""Dispatcher for fetching blog post links from different reviewers."""
+from .sources import baradwajrangan_links
 
-from utils.logger import get_logger
-from utils.io_helpers import write_failure
-from db.review_queries import get_latest_post_date, get_recent_links
-
-BASE_URL = "https://baradwajrangan.wordpress.com"
-CONCURRENT_FETCHES = 10
-MAX_RETRIES = 3
-semaphore = asyncio.Semaphore(CONCURRENT_FETCHES)
-
-logger = get_logger(__name__)
-
-HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/122.0.0.0 Safari/537.36"
-    )
+SOURCES = {
+    "baradwajrangan": baradwajrangan_links,
 }
 
-def extract_links_from_html(html: str, page: int) -> list[tuple[int, int, str]]:
-    soup = BeautifulSoup(html, "html.parser")
-
-    anchors = soup.select(
-        "div.featured_content h2 a[rel='bookmark'], div.post h2 a[rel='bookmark']"
-    )
-
-    return [
-        (page, idx, urljoin(BASE_URL, a["href"]))
-        for idx, a in enumerate(anchors)
-        if a.get("href")
-    ]
-
-async def fetch_listing_page(session: aiohttp.ClientSession, page: int) -> list[tuple[int, int, str]]:
-    url = BASE_URL if page == 1 else f"{BASE_URL}/page/{page}/"
-    logger.info("Fetching %s", url)
-
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            async with semaphore:
-                async with async_timeout.timeout(10):
-                    async with session.get(url, headers=HEADERS) as response:
-                        html = await response.text()
-
-                        if page == 1 and attempt == 1:
-                            with open("debug_page_1.html", "w") as f:
-                                f.write(html)
-
-                        logger.info("Page %s attempt %s length=%s", page, attempt, len(html))
-                        return extract_links_from_html(html, page)
-
-        except Exception as e:
-            logger.warning("Attempt %s failed for page %s: %s", attempt, page, e)
-            await asyncio.sleep(2 ** (attempt - 1))
-
-    logger.error("Giving up on page %s after %s retries", page, MAX_RETRIES)
-    write_failure("failed_pages.txt", str(page), "max retries")
-    return []
-
-async def get_post_links_async(start_page: int = 1, end_page: int = 279) -> list[tuple[int, int, str]]:
-    """
-    Fetch blog post links between start_page and end_page.
-    Stops early if a recent link (already stored) is encountered.
-    """
-    recent_links = get_recent_links()
-
-    connector = aiohttp.TCPConnector(limit=CONCURRENT_FETCHES)
-    all_links: list[tuple[int, int, str]] = []
-
-    async with aiohttp.ClientSession(connector=connector) as session:
-        for page in range(start_page, end_page + 1):
-            page_links = await fetch_listing_page(session, page)
-
-            for triple in page_links:
-                if triple[2] in recent_links:
-                    logger.info("Encountered known link: %s — stopping fetch early.", triple[2])
-                    return all_links
-                all_links.append(triple)
-
-    logger.info("Fetched total of %s links before early stop or completion", len(all_links))
-    return all_links
-
-def get_post_links(page: int) -> list[str]:
-    """
-    Sync wrapper for fetch_listing_page(). Used in RQ jobs.
-    """
-    async def run():
-        async with aiohttp.ClientSession() as session:
-            results = await fetch_listing_page(session, page)
-            return [url for (_, _, url) in results]
-
-    return asyncio.run(run())
+async def get_post_links_async(start_page: int = 1, end_page: int = 279, reviewer: str = "baradwajrangan") -> list[tuple[int, int, str]]:
+    """Fetch blog post links for the given reviewer."""
+    source = SOURCES.get(reviewer)
+    if not source:
+        raise ValueError(f"Unknown reviewer: {reviewer}")
+    return await source.get_post_links_async(start_page, end_page)

--- a/backend/crawler/parse_post.py
+++ b/backend/crawler/parse_post.py
@@ -1,108 +1,14 @@
-import argparse
-import json
-import requests
-from bs4 import BeautifulSoup
-import re
-import sys
-
-# --- SYNC version (unchanged) ---
-def parse_post(url: str) -> dict:
-    response = requests.get(url, timeout=10)
-    response.raise_for_status()
-    soup = BeautifulSoup(response.text, "html.parser")
-    print("parse_post")
-
-    # Extract title
-    title = soup.select_one("#header-about h1")
-    title = title.get_text(strip=True) if title else "unknown"
-
-    # Extract date
-    date_text = soup.select_one(".date-comments em")
-    date = date_text.get_text(strip=True).replace("Posted on ", "") if date_text else "unknown"
-
-    # Extract short review (first paragraph inside .entry)
-    short_review = ""
-    entry_div = soup.select_one("div.entry")
-    if entry_div:
-        paragraphs = entry_div.find_all("p")
-        if paragraphs:
-            short_review = paragraphs[0].get_text(strip=True)
-
-    # Extract full review (all <p> in .entry except trailer/links)
-    full_review = ""
-    if entry_div:
-        paras = entry_div.find_all("p")
-        filtered = [
-            p.get_text(strip=True)
-            for p in paras
-            if not p.find("a") and "watch the trailer" not in p.get_text(strip=True).lower()
-        ]
-        full_review = "\n\n".join(filtered)
-
-    return {
-        "url": url,
-        "title": title,
-        "summary": short_review,
-        "date": date,
-        "full_review": full_review
-    }
-
-# --- ASYNC version for batch processing ---
+"""Dispatcher for parsing blog posts from different reviewers."""
 import aiohttp
+from .sources import baradwajrangan_parse
 
-async def parse_post_async(session: aiohttp.ClientSession, url: str) -> dict:
-    async with session.get(url, timeout=10) as response:
-        print("in parse_post")
-        response.raise_for_status()
-        text = await response.text()
-        soup = BeautifulSoup(text, "html.parser")
-      
+SOURCES = {
+    "baradwajrangan": baradwajrangan_parse,
+}
 
-        # Extract title
-        title = soup.select_one("#header-about h1")
-        title = title.get_text(strip=True) if title else "unknown"
-
-        # Extract date
-        date_text = soup.select_one(".date-comments em")
-        date = date_text.get_text(strip=True).replace("Posted on ", "") if date_text else "unknown"
-
-        # Extract short review (first paragraph inside .entry)
-        short_review = ""
-        entry_div = soup.select_one("div.entry")
-        if entry_div:
-            paragraphs = entry_div.find_all("p")
-            if paragraphs:
-                short_review = paragraphs[0].get_text(strip=True)
-
-        # Extract full review (all <p> in .entry except trailer/links)
-        full_review = ""
-        if entry_div:
-            paras = entry_div.find_all("p")
-            filtered = [
-                p.get_text(strip=True)
-                for p in paras
-                if not p.find("a") and "watch the trailer" not in p.get_text(strip=True).lower()
-            ]
-            full_review = "\n\n".join(filtered)
-
-        return {
-            "url": url,
-            "title": title,
-            "summary": short_review,
-            "date": date,
-            "full_review": full_review
-        }
-
-# --- CLI for sync version ---
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--url", required=True, help="URL of the blog post")
-    args = parser.parse_args()
-    print(args.url)
-    try:
-        print(f"[DEBUG] Parsing {args.url}", file=sys.stderr, flush=True)
-        post_data = parse_post(args.url)
-        print(json.dumps(post_data), flush=True)
-    except Exception as e:
-        print(f"[ERROR] {e}", file=sys.stderr, flush=True)
-        exit(1)
+async def parse_post_async(session: aiohttp.ClientSession, url: str, reviewer: str = "baradwajrangan") -> dict:
+    """Parse a single blog post URL for the given reviewer."""
+    source = SOURCES.get(reviewer)
+    if not source:
+        raise ValueError(f"Unknown reviewer: {reviewer}")
+    return await source.parse_post_async(session, url)

--- a/backend/crawler/sources/__init__.py
+++ b/backend/crawler/sources/__init__.py
@@ -1,0 +1,4 @@
+from . import baradwajrangan_links
+from . import baradwajrangan_parse
+
+__all__ = ["baradwajrangan_links", "baradwajrangan_parse"]

--- a/backend/crawler/sources/baradwajrangan_links.py
+++ b/backend/crawler/sources/baradwajrangan_links.py
@@ -1,0 +1,98 @@
+import asyncio
+import aiohttp
+import async_timeout
+from tqdm.asyncio import tqdm
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+from utils.logger import get_logger
+from utils.io_helpers import write_failure
+from db.review_queries import get_latest_post_date, get_recent_links
+
+BASE_URL = "https://baradwajrangan.wordpress.com"
+CONCURRENT_FETCHES = 10
+MAX_RETRIES = 3
+semaphore = asyncio.Semaphore(CONCURRENT_FETCHES)
+
+logger = get_logger(__name__)
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/122.0.0.0 Safari/537.36"
+    )
+}
+
+def extract_links_from_html(html: str, page: int) -> list[tuple[int, int, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+
+    anchors = soup.select(
+        "div.featured_content h2 a[rel='bookmark'], div.post h2 a[rel='bookmark']"
+    )
+
+    return [
+        (page, idx, urljoin(BASE_URL, a["href"]))
+        for idx, a in enumerate(anchors)
+        if a.get("href")
+    ]
+
+async def fetch_listing_page(session: aiohttp.ClientSession, page: int) -> list[tuple[int, int, str]]:
+    url = BASE_URL if page == 1 else f"{BASE_URL}/page/{page}/"
+    logger.info("Fetching %s", url)
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            async with semaphore:
+                async with async_timeout.timeout(10):
+                    async with session.get(url, headers=HEADERS) as response:
+                        html = await response.text()
+
+                        if page == 1 and attempt == 1:
+                            with open("debug_page_1.html", "w") as f:
+                                f.write(html)
+
+                        logger.info("Page %s attempt %s length=%s", page, attempt, len(html))
+                        return extract_links_from_html(html, page)
+
+        except Exception as e:
+            logger.warning("Attempt %s failed for page %s: %s", attempt, page, e)
+            await asyncio.sleep(2 ** (attempt - 1))
+
+    logger.error("Giving up on page %s after %s retries", page, MAX_RETRIES)
+    write_failure("failed_pages.txt", str(page), "max retries")
+    return []
+
+async def get_post_links_async(start_page: int = 1, end_page: int = 279) -> list[tuple[int, int, str]]:
+    """
+    Fetch blog post links between start_page and end_page.
+    Stops early if a recent link (already stored) is encountered.
+    """
+    recent_links = get_recent_links()
+
+    connector = aiohttp.TCPConnector(limit=CONCURRENT_FETCHES)
+    all_links: list[tuple[int, int, str]] = []
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        for page in range(start_page, end_page + 1):
+            page_links = await fetch_listing_page(session, page)
+
+            for triple in page_links:
+                if triple[2] in recent_links:
+                    logger.info("Encountered known link: %s — stopping fetch early.", triple[2])
+                    return all_links
+                all_links.append(triple)
+
+    logger.info("Fetched total of %s links before early stop or completion", len(all_links))
+    return all_links
+
+def get_post_links(page: int) -> list[str]:
+    """
+    Sync wrapper for fetch_listing_page(). Used in RQ jobs.
+    """
+    async def run():
+        async with aiohttp.ClientSession() as session:
+            results = await fetch_listing_page(session, page)
+            return [url for (_, _, url) in results]
+
+    return asyncio.run(run())

--- a/backend/crawler/sources/baradwajrangan_parse.py
+++ b/backend/crawler/sources/baradwajrangan_parse.py
@@ -1,0 +1,108 @@
+import argparse
+import json
+import requests
+from bs4 import BeautifulSoup
+import re
+import sys
+
+# --- SYNC version (unchanged) ---
+def parse_post(url: str) -> dict:
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    print("parse_post")
+
+    # Extract title
+    title = soup.select_one("#header-about h1")
+    title = title.get_text(strip=True) if title else "unknown"
+
+    # Extract date
+    date_text = soup.select_one(".date-comments em")
+    date = date_text.get_text(strip=True).replace("Posted on ", "") if date_text else "unknown"
+
+    # Extract short review (first paragraph inside .entry)
+    short_review = ""
+    entry_div = soup.select_one("div.entry")
+    if entry_div:
+        paragraphs = entry_div.find_all("p")
+        if paragraphs:
+            short_review = paragraphs[0].get_text(strip=True)
+
+    # Extract full review (all <p> in .entry except trailer/links)
+    full_review = ""
+    if entry_div:
+        paras = entry_div.find_all("p")
+        filtered = [
+            p.get_text(strip=True)
+            for p in paras
+            if not p.find("a") and "watch the trailer" not in p.get_text(strip=True).lower()
+        ]
+        full_review = "\n\n".join(filtered)
+
+    return {
+        "url": url,
+        "title": title,
+        "summary": short_review,
+        "date": date,
+        "full_review": full_review
+    }
+
+# --- ASYNC version for batch processing ---
+import aiohttp
+
+async def parse_post_async(session: aiohttp.ClientSession, url: str) -> dict:
+    async with session.get(url, timeout=10) as response:
+        print("in parse_post")
+        response.raise_for_status()
+        text = await response.text()
+        soup = BeautifulSoup(text, "html.parser")
+      
+
+        # Extract title
+        title = soup.select_one("#header-about h1")
+        title = title.get_text(strip=True) if title else "unknown"
+
+        # Extract date
+        date_text = soup.select_one(".date-comments em")
+        date = date_text.get_text(strip=True).replace("Posted on ", "") if date_text else "unknown"
+
+        # Extract short review (first paragraph inside .entry)
+        short_review = ""
+        entry_div = soup.select_one("div.entry")
+        if entry_div:
+            paragraphs = entry_div.find_all("p")
+            if paragraphs:
+                short_review = paragraphs[0].get_text(strip=True)
+
+        # Extract full review (all <p> in .entry except trailer/links)
+        full_review = ""
+        if entry_div:
+            paras = entry_div.find_all("p")
+            filtered = [
+                p.get_text(strip=True)
+                for p in paras
+                if not p.find("a") and "watch the trailer" not in p.get_text(strip=True).lower()
+            ]
+            full_review = "\n\n".join(filtered)
+
+        return {
+            "url": url,
+            "title": title,
+            "summary": short_review,
+            "date": date,
+            "full_review": full_review
+        }
+
+# --- CLI for sync version ---
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", required=True, help="URL of the blog post")
+    args = parser.parse_args()
+    print(args.url)
+    try:
+        print(f"[DEBUG] Parsing {args.url}", file=sys.stderr, flush=True)
+        post_data = parse_post(args.url)
+        print(json.dumps(post_data), flush=True)
+    except Exception as e:
+        print(f"[ERROR] {e}", file=sys.stderr, flush=True)
+        exit(1)

--- a/backend/pipeline/__init__.py
+++ b/backend/pipeline/__init__.py
@@ -6,12 +6,14 @@ from . import step_3_classify_reviews
 from . import step_4_link_movies
 from . import step_5_generate_sentiment
 from . import step_6_enrich_metadata
+from . import step_3b_llm_validation
 
 __all__ = [
     "step_1_fetch_links",
     "step_2_parse_posts",
     "step_3_classify_reviews",
     "step_4_link_movies",
+    "step_3b_llm_validation",
     "step_5_generate_sentiment",
     "step_6_enrich_metadata",
 ]

--- a/backend/pipeline/step_1_fetch_links.py
+++ b/backend/pipeline/step_1_fetch_links.py
@@ -5,17 +5,17 @@ from db.store_review import store_blog_post_urls
 from utils import StepLogger
 
 
-async def fetch_links(start_page: int = 1, end_page: int = 279) -> list[str]:
+async def fetch_links(start_page: int = 1, end_page: int = 279, reviewer: str = "baradwajrangan") -> list[str]:
     """Fetch blog post links and persist them."""
     step_logger = StepLogger("step_1_fetch_links")
-    links = await get_post_links_async(start_page, end_page)
+    links = await get_post_links_async(start_page, end_page, reviewer)
     step_logger.metrics["input_count"] = len(links)
     step_logger.logger.info("Discovered %s new links", len(links))
 
     for link in links:
         step_logger.metrics["processed_count"] += 1
         try:
-            store_blog_post_urls({"link": link[2], "blog_title": "TBD"})
+            store_blog_post_urls({"link": link[2], "blog_title": "TBD", "reviewer": reviewer})
             step_logger.metrics["saved_count"] += 1
         except Exception as e:
             step_logger.metrics["failed_count"] += 1

--- a/backend/pipeline/step_2_parse_posts.py
+++ b/backend/pipeline/step_2_parse_posts.py
@@ -22,13 +22,14 @@ async def _parse_and_store(
     session: aiohttp.ClientSession,
     url: dict,
     step_logger: StepLogger,
+    reviewer: str,
     attempt: int = 1,
 ) -> None:
     """Parse a blog post URL and persist the result."""
     try:
         async with semaphore:
             async with async_timeout.timeout(10):
-                data = await parse_post_async(session, url["link"])
+                data = await parse_post_async(session, url["link"], reviewer)
 
         for key in ["url", "title", "summary", "full_review", "date"]:
             if key not in data:
@@ -65,7 +66,7 @@ async def _parse_and_store(
         )
         raise
 
-async def parse_posts(urls: list[str]) -> None:
+async def parse_posts(urls: list[str], reviewer: str = "baradwajrangan") -> None:
     """Parse and store a list of blog post URLs."""
     step_logger = StepLogger("step_2_parse_posts")
     if not urls:
@@ -79,7 +80,7 @@ async def parse_posts(urls: list[str]) -> None:
         tasks = [
             run_with_retries(
                 _parse_and_store,
-                args=[session, url, step_logger],
+                args=[session, url, step_logger, reviewer],
                 max_retries=MAX_RETRIES,
             )
             for url in unique

--- a/backend/pipeline/step_3b_llm_validation.py
+++ b/backend/pipeline/step_3b_llm_validation.py
@@ -1,0 +1,9 @@
+"""Step 3b: placeholder for additional LLM based validations."""
+from utils import StepLogger
+
+
+def validate_reviews() -> None:
+    """Run extra validation steps on parsed reviews using LLMs."""
+    step_logger = StepLogger("step_3b_llm_validation")
+    step_logger.logger.info("LLM validation not yet implemented")
+    step_logger.finalize()

--- a/backend/reviewers.py
+++ b/backend/reviewers.py
@@ -1,0 +1,26 @@
+"""Registry of available reviewers for crawling."""
+
+from dataclasses import dataclass
+from typing import Callable, Awaitable, List
+
+import aiohttp
+from crawler.fetch_links import SOURCES as LINK_SOURCES
+from crawler.parse_post import SOURCES as PARSE_SOURCES
+
+
+@dataclass
+class Reviewer:
+    id: str
+    base_url: str
+    link_source: Callable[[int, int], Awaitable[List[tuple[int, int, str]]]]
+    parse_source: Callable[[aiohttp.ClientSession, str], Awaitable[dict]]
+
+
+REVIEWERS: dict[str, Reviewer] = {
+    "baradwajrangan": Reviewer(
+        id="baradwajrangan",
+        base_url="https://baradwajrangan.wordpress.com",
+        link_source=LINK_SOURCES["baradwajrangan"].get_post_links_async,
+        parse_source=PARSE_SOURCES["baradwajrangan"].parse_post_async,
+    ),
+}

--- a/backend/run_pipeline.py
+++ b/backend/run_pipeline.py
@@ -5,6 +5,7 @@ from pipeline import (
     step_1_fetch_links,
     step_2_parse_posts,
     step_3_classify_reviews,
+    step_3b_llm_validation,
     step_4_link_movies,
     step_5_generate_sentiment,
     step_6_enrich_metadata,
@@ -13,28 +14,50 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-async def main(limit: int | None = None, dry_run: bool = False) -> None:
-    logger.info("Starting pipeline run")
-    links = await step_1_fetch_links.fetch_links()
+async def crawl(limit: int | None = None, dry_run: bool = False, reviewer: str = "baradwajrangan") -> list[str]:
+    logger.info("Starting crawl stage")
+    links = await step_1_fetch_links.fetch_links(reviewer=reviewer)
     if limit:
         links = links[:limit]
         logger.debug("Limiting to %s links", limit)
 
     if dry_run:
         logger.info("Dry run enabled - exiting early")
-        return
+        return []
 
-    await step_2_parse_posts.parse_posts(links)
+    await step_2_parse_posts.parse_posts(links, reviewer=reviewer)
+    logger.info("Crawl stage complete")
+    return links
+
+
+def validate() -> None:
+    logger.info("Starting validation stage")
     step_3_classify_reviews.classify_reviews()
+    step_3b_llm_validation.validate_reviews()
     step_4_link_movies.link_movies()
+    logger.info("Validation stage complete")
+
+
+async def enrich() -> None:
+    logger.info("Starting enrichment stage")
     step_5_generate_sentiment.generate_sentiment()
     await step_6_enrich_metadata.enrich_metadata()
+    logger.info("Enrichment stage complete")
+
+
+async def main(limit: int | None = None, dry_run: bool = False, reviewer: str = "baradwajrangan") -> None:
+    await crawl(limit=limit, dry_run=dry_run, reviewer=reviewer)
+    if dry_run:
+        return
+    validate()
+    await enrich()
     logger.info("Pipeline run complete")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run enrichment pipeline")
     parser.add_argument("--limit", type=int, help="Limit number of links to process")
     parser.add_argument("--dry-run", action="store_true", help="Run fetch step only")
+    parser.add_argument("--reviewer", default="baradwajrangan", help="Reviewer id to crawl")
     args = parser.parse_args()
 
-    asyncio.run(main(limit=args.limit, dry_run=args.dry_run))
+    asyncio.run(main(limit=args.limit, dry_run=args.dry_run, reviewer=args.reviewer))


### PR DESCRIPTION
## Summary
- modularize crawler so sources can be plugged in
- add reviewer registry
- split pipeline into crawl/validate/enrich stages
- add scaffolding step for future LLM validation
- support reviewer argument in pipeline runner

## Testing
- `pyenv local 3.11.12`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d855284483249d88b5ba40e02e43